### PR TITLE
Test use existing hostname - elementalregistration

### DIFF
--- a/tests/assets/capi_elementalRegistration.yaml
+++ b/tests/assets/capi_elementalRegistration.yaml
@@ -13,8 +13,7 @@ spec:
         uri: https://%ELEMENTAL_API_ENDPOINT%:30009/elemental/v1/namespaces/default/registrations/machine-registration-master-%CLUSTER_NAME%
       agent:
         hostname:
-          useExisting: false
-          prefix: "m-"
+          useExisting: true
         debug: true
         osPlugin: "/usr/lib/elemental/plugins/elemental.so"
         workDir: "/oem/elemental/agent"


### PR DESCRIPTION
Use the existing hostname, better for future checks than using a random hostname.

## Verification run:
https://github.com/rancher-sandbox/elemental-e2e/actions/runs/9516496432 ✅ 