### PR TITLE
Build local elemental-agent image

### DIFF
--- a/.github/workflows/sub_capi_cli.yaml
+++ b/.github/workflows/sub_capi_cli.yaml
@@ -150,13 +150,19 @@ jobs:
           ELEMENTAL_API_ENABLE_TLS: "\"true\""
           ELEMENTAL_ENABLE_DEFAULT_CA: "\"true\""
           OPERATOR_TYPE: "capi"
-          
+
+      - name: Build the elemental-agent container image
+        id: build_elemental-agent
+        run: |
+          cd cluster-api-provider-elemental
+          make docker-build-agent
+
       - name: Build the ISO image
         id: build_iso
         run: |
           cd cluster-api-provider-elemental 
           if ${{ contains(inputs.bootstrap_provider, 'kubeadm') }}; then
-            AGENT_CONFIG_FILE=iso/config/my-config.yaml make build-iso-kubeadm
+            AGENT_CONFIG_FILE=iso/config/my-config.yaml KUBEADM_READY_OS=true make build-iso
           else
             AGENT_CONFIG_FILE=iso/config/my-config.yaml make build-iso
           fi


### PR DESCRIPTION
@juadk this is a fix due to the recent changes of https://github.com/rancher-sandbox/cluster-api-provider-elemental/pull/81

Mainly there are two major changes:
- We have only one dev image, the kubeadm stack can be optionally installed with `KUBEADM_READY_OS=true` when building the OS container.
- The `elemental-agent` (and plugins) has its own container image now. By default we use the `latest` tag, which should normally point to the latest stable release (not yet available), but by using `make docker-build-agent` you can build a `latest` image as well. This gives you the option to build the image locally when you are testing `main`, not build anything locally if you want to test `latest` stable released image, or pin it to some explicit version: `ELEMENTAL_AGENT_IMAGE=ghcr.io/rancher-sandbox/cluster-api-provider-elemental/agent:v0.6.0 make build-iso` 