### PR TITLE
Use main branch to run tests

### DIFF
--- a/.github/workflows/sub_capi_cli.yaml
+++ b/.github/workflows/sub_capi_cli.yaml
@@ -97,7 +97,7 @@ jobs:
         with:
           repository: rancher-sandbox/cluster-api-provider-elemental
           path: cluster-api-provider-elemental
-          ref: debug_branch
+          ref: main
 
       - name: Setup Go
         id: setup_go


### PR DESCRIPTION
@juadk just noticed that the last change I pushed broke the tests.
This should fix it. 

I am also not sure whether the `debug_branch` is still relevant after the unification of kubeadm/non-kubeadm images.